### PR TITLE
Automatically publish documentation on pursuit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ script:
   - npm install pouchdb
   - bower install
   - pulp test
+after_success:
+  - test $TRAVIS_TAG &&
+    echo $GITHUB_TOKEN | pulp login &&
+    echo y | pulp publish --no-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: node
 dist: trusty
-sudo: false
+sudo: required
 install:
   - npm install -g bower purescript pulp
   - npm install pouchdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ dist: trusty
 sudo: false
 install:
   - npm install -g bower purescript pulp
-script:
   - npm install pouchdb
+script:
+  - bower install --production
+  - pulp build
   - bower install
   - pulp test
 after_success:


### PR DESCRIPTION
This requires a `GITHUB_TOKEN` environment variable to be set (in travis). This token was obtained by following the instructions printed by `purs login`.