### PR TITLE
Use global PouchDB object instead of requiring module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ dist: trusty
 sudo: required
 install:
   - npm install -g bower purescript pulp
-  - npm install pouchdb@6.4.1
+  - npm install pouchdb@6.4.2
 script:
-  - bower install --production
-  - pulp build
   - bower install
-  - pulp test
+  - make test
 after_success:
   - test $TRAVIS_TAG &&
     echo $GITHUB_TOKEN | pulp login &&

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test
+
+SOURCES = $(shell find src/)
+TEST_SOURCES = $(shell find test/)
+
+output/Test.Main/index.js: $(SOURCES) $(TEST_SOURCES)
+	purs compile 'bower_components/*/src/**/*.purs' 'src/**/*.purs' 'test/**/*.purs'
+
+test: output/Test.Main/index.js
+	node -e 'global.PouchDB = require("pouchdb");require("./output/Test.Main").main()'

--- a/src/Database/PouchDB/FFI.js
+++ b/src/Database/PouchDB/FFI.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const _pouchdb = require('pouchdb');
-
 function callback (e, r) {
     return function (err, response) {
         if (err)
@@ -20,7 +18,7 @@ function nonCanceller() {
 
 exports.pouchDB = function (options) {
     return function () {
-        return new _pouchdb(options);
+        return new PouchDB(options);
     }}
 
 exports.destroy = function (db) {
@@ -87,7 +85,7 @@ exports.replicate = function (source) {
     return function (target) {
         return function (options) {
             return function () {
-                return _pouchdb.replicate(source, target, options);
+                return PouchDB.replicate(source, target, options);
             }}}}
 
 exports.replicateTo = function (source) {
@@ -105,7 +103,7 @@ exports.sync = function (source) {
     return function (target) {
         return function (options) {
             return function () {
-                return _pouchdb.sync(source, target, options);
+                return PouchDB.sync(source, target, options);
             }}}}
 
 exports.putAttachment = function (db) {


### PR DESCRIPTION
This makes it easier to use in the browser: just add a script tag with
the hosted pouchdb.min.js. It also makes it easier to use custom
builds of PouchDB, like the pouchdb-node or pouchdb-browser builds.

To be revisited when JavaScript modules are less of a mess. Surprised
as I am, this seems like a problem functors (ML-style, on the module
level) would solve.

Also in this commit:
- test against PouchDB to 6.4.2
- use make instead of pulp for building and running tests